### PR TITLE
Fix: Padroniza cookies de sessão para integração de login

### DIFF
--- a/frontend-app/src/lib/supabaseClient.ts
+++ b/frontend-app/src/lib/supabaseClient.ts
@@ -227,11 +227,11 @@ const createSupabaseClient = (): SupabaseClient<Database> => {
     auth: {
       persistSession: true,
       detectSessionInUrl: true,
-      storageKey: `sb-flux-${config.environment}`,
+      storageKey: `sb-flux-session`, // PADRONIZADO
       autoRefreshToken: true,
       flowType: 'pkce',
       debug: config.debug,
-      storage: createCustomStorage() // ✅ CORRETO: removido "..."
+      storage: createCustomStorage()
     },
     global: {
       headers: {

--- a/frontend-hostinger/public_html/login.html
+++ b/frontend-hostinger/public_html/login.html
@@ -375,11 +375,11 @@ body {
         const maxAge = 100 * 365 * 24 * 60 * 60; // 100 anos
         const secure = window.location.protocol === 'https:';
         
-        // ✅ Salvar tokens individuais
-        document.cookie = `flux-access-token=${session.access_token}; Domain=.fluxrevenue.com.br; path=/; max-age=${maxAge}; SameSite=Lax; ${secure ? 'secure' : ''}`;
-        document.cookie = `flux-refresh-token=${session.refresh_token}; Domain=.fluxrevenue.com.br; path=/; max-age=${maxAge}; SameSite=Lax; ${secure ? 'secure' : ''}`;
+        // ✅ Salvar tokens individuais (PADRONIZADO)
+        document.cookie = `flux_access_token=${session.access_token}; Domain=.fluxrevenue.com.br; path=/; max-age=${maxAge}; SameSite=Lax; ${secure ? 'secure' : ''}`;
+        document.cookie = `flux_refresh_token=${session.refresh_token}; Domain=.fluxrevenue.com.br; path=/; max-age=${maxAge}; SameSite=Lax; ${secure ? 'secure' : ''}`;
         
-        // ✅ Salvar sessão completa
+        // ✅ Salvar sessão completa (PADRONIZADO)
         const sessionData = JSON.stringify({
           access_token: session.access_token,
           refresh_token: session.refresh_token,
@@ -387,9 +387,9 @@ body {
           user: session.user
         });
         
-        document.cookie = `sb-flux-auth-token=${encodeURIComponent(sessionData)}; Domain=.fluxrevenue.com.br; path=/; max-age=${maxAge}; SameSite=Lax; ${secure ? 'secure' : ''}`;
+        document.cookie = `sb-flux-session=${encodeURIComponent(sessionData)}; Domain=.fluxrevenue.com.br; path=/; max-age=${maxAge}; SameSite=Lax; ${secure ? 'secure' : ''}`;
         
-        console.log('✅ [Login] Cookies cross-domain salvos:', {
+        console.log('✅ [Login] Cookies cross-domain PADRONIZADOS salvos:', {
           user: session.user.email,
           domain: '.fluxrevenue.com.br'
         });


### PR DESCRIPTION
- Altera login.html para usar nomes de cookie flux_access_token, flux_refresh_token, e sb-flux-session.
- Modifica supabaseClient.ts em frontend-app para usar sb-flux-session como storageKey e garante que CustomStorage seja compatível.
- Revisa AuthContext.tsx e a inicialização do Supabase na app principal, confirmando que devem funcionar com os cookies padronizados.

Este conjunto de alterações visa resolver problemas onde a sessão de autenticação estabelecida na página de login não era corretamente reconhecida pela aplicação principal no subdomínio app.fluxrevenue.com.br.